### PR TITLE
Fix `parse_file/1`'s error handling

### DIFF
--- a/lib/id3vx.ex
+++ b/lib/id3vx.ex
@@ -109,13 +109,13 @@ defmodule Id3vx do
   It will open the file read-only and only read as many bytes as
   necessary.
 
-  Returns `{:ok, Id3vx.Tag}` struct or throws an `{:error, Id3vx.Error}`.
+  Returns `{:ok, Id3vx.Tag}` struct or returns `{:error, Id3vx.Error}`.
   """
   @spec parse_file(path :: String.t()) :: {:ok, Tag.t()} | {:error, %Error{}}
   def parse_file(path) do
     try do
       {:ok, parse_file!(path)}
-    catch
+    rescue
       e -> {:error, e}
     end
   end

--- a/test/id3vx_test.exs
+++ b/test/id3vx_test.exs
@@ -679,6 +679,16 @@ defmodule Id3vxTest do
            } = tag
   end
 
+  test "parse_file!/1 raises an error when parsing a non-mp3" do
+    assert_raise Id3vx.Error, fn ->
+      Id3vx.parse_file!(__ENV__.file)
+    end
+  end
+
+  test "parse_file/1 returns error tuple when parsing a non-mp3" do
+    assert {:error, %Id3vx.Error{}} = Id3vx.parse_file(__ENV__.file)
+  end
+
   test "Replace tag in mp3 file" do
     path = Path.join(@samples_path, "beamradio32.mp3")
     outpath = "/tmp/out.mp3"


### PR DESCRIPTION
`parse_file/1` was throwing an error (just like `parse_file!/1` does) instead of returning `{:error, Id3vx.Error}` because we accidentally used `catch` instead of `rescue`. Fixed that and added two more parsing tests (not sure if it's the best place for those, please move if not!)